### PR TITLE
Use undefined instead of null as the default value of fields

### DIFF
--- a/compile.js
+++ b/compile.js
@@ -225,7 +225,7 @@ function compileDest(ctx) {
     for (var i = 0; i < ctx._proto.fields.length; i++) {
         var field = ctx._proto.fields[i];
         props[field.name + ': ' + JSON.stringify(ctx._defaults[field.name])] = true;
-        if (field.oneof) props[field.oneof + ': null'] = true;
+        if (field.oneof) props[field.oneof + ': undefined'] = true;
     }
     return '{' + Object.keys(props).join(', ') + '}';
 }

--- a/compile.js
+++ b/compile.js
@@ -422,7 +422,7 @@ function getDefaultValue(field, value) {
     case 'string':   return value || '';
     case 'bool':     return value === 'true';
     case 'map':      return {};
-    default:         return null;
+    default:         return undefined;
     }
 }
 


### PR DESCRIPTION
This fixes the issue with types in the Typescript generated code. I'm not sure about the `return undefined` bit - not sure exactly what that value is used for.