### PR TITLE
Fix generated code compatibility with strict null checks

### DIFF
--- a/compile.js
+++ b/compile.js
@@ -147,7 +147,7 @@ function writeMessage(ctx, options) {
         code += ctx._indent + '    ' + compileFunctionHead(options, 'read', 'pbf, end', 'pbf: Pbf, end?: number', getTypescriptInterfaceName(ctx)) + ' {\n';
         code += ctx._indent + '        return pbf.readFields(' + ctx._fullName + '._readField, ' + compileDest(ctx) + ', end);\n';
         code += ctx._indent + '    },\n';
-        code += ctx._indent + '    ' + compileFunctionHead(options, '_readField', 'tag, obj, pbf', 'tag: number, obj: any, pbf: Pbf', 'void') + ' {\n';
+        code += ctx._indent + '    ' + compileFunctionHead(options, '_readField', 'tag, obj, pbf', 'tag: number, obj: any, pbf?: Pbf', 'void') + ' {\n';
 
         var hasVarEntry = false;
         for (var i = 0; i < fields.length; i++) {
@@ -163,7 +163,7 @@ function writeMessage(ctx, options) {
                 hasVarEntry = true;
             }
             code += ctx._indent + '        ' + (i ? 'else if' : 'if') +
-                ' (tag === ' + field.tag + ') ' +
+                ' (tag === ' + field.tag + ' && pbf) ' +
                 (field.type === 'map' ? ' { ' : '') +
                 (
                     field.type === 'map' ? compileMapRead(readCode, field.name) :
@@ -184,7 +184,7 @@ function writeMessage(ctx, options) {
     }
 
     if (!options.noWrite) {
-        code += ctx._indent + '    ' + compileFunctionHead(options, 'write', 'obj, pbf', 'obj: ' + getTypescriptInterfaceName(ctx) + ', pbf: Pbf', 'void') + ' {\n';
+        code += ctx._indent + '    ' + compileFunctionHead(options, 'write', 'obj, pbf', 'obj: ' + getTypescriptInterfaceName(ctx) + ', pbf?: Pbf', 'void') + ' {\n';
         var numRepeated = 0;
         for (i = 0; i < fields.length; i++) {
             field = fields[i];
@@ -556,7 +556,7 @@ function getDefaultWriteTest(ctx, field) {
         }
     }
 
-    return code + ') ';
+    return code + ' && pbf) ';
 }
 
 function isPacked(field) {

--- a/compile.js
+++ b/compile.js
@@ -49,7 +49,7 @@ function writeTypes(ctx, options) {
             var oneOfName = field.oneof;
             if (oneOfName && !isOneOfAdded[oneOfName]) {
                 var oneOfValues = getOneOfValues(fields, oneOfName);
-                code += '    ' + oneOfName + ': ' + oneOfValues.map(value => JSON.stringify(value)).join(' | ') + ';\n';
+                code += '    ' + oneOfName + '?: ' + oneOfValues.map(value => JSON.stringify(value)).join(' | ') + ';\n';
                 isOneOfAdded[oneOfName] = true;
             }
 
@@ -225,7 +225,7 @@ function compileDest(ctx) {
     for (var i = 0; i < ctx._proto.fields.length; i++) {
         var field = ctx._proto.fields[i];
         props[field.name + ': ' + JSON.stringify(ctx._defaults[field.name])] = true;
-        if (field.oneof) props[field.oneof + ': null'] = true;
+        if (field.oneof) props[field.oneof + ': undefined'] = true;
     }
     return '{' + Object.keys(props).join(', ') + '}';
 }
@@ -422,7 +422,7 @@ function getDefaultValue(field, value) {
     case 'string':   return value || '';
     case 'bool':     return value === 'true';
     case 'map':      return {};
-    default:         return null;
+    default:         return undefined;
     }
 }
 


### PR DESCRIPTION
For this proto file:

```proto
syntax = "proto3";

message JoinMessage { string channel = 1; }

message ChatMessage {
  uint32 id = 1;
  string message = 2;
}

message RPCMessage {
  oneof msg {
    JoinMessage join = 1;
    ChatMessage chat = 2;
  }
}
```

This change generates:

```typescript
// code generated by pbf v3.2.0
/* tslint:disable */

import Pbf from 'pbf';

export interface IJoinMessage {
    channel?: string;
}

export interface IChatMessage {
    id?: number;
    message?: string;
}

export interface IRPCMessage {
    msg?: "join" | "chat";
    join?: IJoinMessage;
    chat?: IChatMessage;
}

export const JoinMessage = {
    read(pbf: Pbf, end?: number): IJoinMessage {
        return pbf.readFields(JoinMessage._readField, {channel: ""}, end);
    },
    _readField(tag: number, obj: any, pbf?: Pbf): void {
        if (tag === 1 && pbf) obj.channel = pbf.readString();
    },
    write(obj: IJoinMessage, pbf?: Pbf): void {
        if (obj.channel && pbf) pbf.writeStringField(1, obj.channel);
    }
};

export const ChatMessage = {
    read(pbf: Pbf, end?: number): IChatMessage {
        return pbf.readFields(ChatMessage._readField, {id: 0, message: ""}, end);
    },
    _readField(tag: number, obj: any, pbf?: Pbf): void {
        if (tag === 1 && pbf) obj.id = pbf.readVarint();
        else if (tag === 2 && pbf) obj.message = pbf.readString();
    },
    write(obj: IChatMessage, pbf?: Pbf): void {
        if (obj.id && pbf) pbf.writeVarintField(1, obj.id);
        if (obj.message && pbf) pbf.writeStringField(2, obj.message);
    }
};

export const RPCMessage = {
    read(pbf: Pbf, end?: number): IRPCMessage {
        return pbf.readFields(RPCMessage._readField, {join: undefined, msg: undefined, chat: undefined}, end);
    },
    _readField(tag: number, obj: any, pbf?: Pbf): void {
        if (tag === 1 && pbf) obj.join = JoinMessage.read(pbf, pbf.readVarint() + pbf.pos), obj.msg = "join";
        else if (tag === 2 && pbf) obj.chat = ChatMessage.read(pbf, pbf.readVarint() + pbf.pos), obj.msg = "chat";
    },
    write(obj: IRPCMessage, pbf?: Pbf): void {
        if (obj.join && pbf) pbf.writeMessage(1, JoinMessage.write, obj.join);
        if (obj.chat && pbf) pbf.writeMessage(2, ChatMessage.write, obj.chat);
    }
};
```

Note the optional pbf argument and if check. This change makes the generated files compatible with `@types/pbf` with `--strictNullChecks`.